### PR TITLE
Fix LoansMenu "F" press bug

### DIFF
--- a/Assets/Scripts/LoansMenu.cs
+++ b/Assets/Scripts/LoansMenu.cs
@@ -54,8 +54,6 @@ public class LoansMenu : MonoBehaviour
 
     void Start()
     {
-        loansmenu.SetActive(false);
-
         //GenerateOffers();
         close.onClick.AddListener(CloseThis);
         up.onClick.AddListener(Increaser);


### PR DESCRIPTION
When setting the LoansMenu gameobject inactive in the Hierarchy, the LoansMenu does open once you press F, however it immediately closes right after because of the SetActive(false) in the Start() function. Which is why the "F" button had to be pressed twice to work (excluding the "F" press to open the tutorial pop-up UI).